### PR TITLE
Update SEGMENT on tab bar

### DIFF
--- a/the-10-min/src/Tabbar/icons/Constants.ts
+++ b/the-10-min/src/Tabbar/icons/Constants.ts
@@ -1,4 +1,4 @@
-import { Dimensions } from "react-native";
+import { Dimensions, PixelRatio } from "react-native";
 
 const { width } = Dimensions.get("window");
 
@@ -10,7 +10,7 @@ const numberOfIcons = 5;
 const horizontalPadding = 48;
 export const DURATION = 450;
 export const PADDING = 16;
-export const SEGMENT = width / numberOfIcons;
+export const SEGMENT = PixelRatio.roundToNearestPixel(width / numberOfIcons);
 export const ICON_SIZE = SEGMENT - horizontalPadding;
 
 export const Colors = {


### PR DESCRIPTION
The 'LTR' / 'RTL' direction change has some effect on the SEGMENT size without pixel rounding I have seen. When the direction changes you get a slight movement that is corrected by pixel rounding the SEGMENT.