### PR TITLE
Fix: Uber eats swipe

### DIFF
--- a/season3/src/UberEatsSwipe/components/Action.tsx
+++ b/season3/src/UberEatsSwipe/components/Action.tsx
@@ -32,7 +32,7 @@ const Action = ({ x, deleteOpacity }: ActionProps) => {
   const borderRadius = divide(size, 2);
   const scale = interpolate(size, {
     inputRange: [20, 30],
-    outputRange: [0.001, 1],
+    outputRange: [0.01, 1],
     extrapolate: Extrapolate.CLAMP,
   });
   const iconOpacity = interpolate(size, {

--- a/season3/src/UberEatsSwipe/components/Item.tsx
+++ b/season3/src/UberEatsSwipe/components/Item.tsx
@@ -22,7 +22,8 @@ import {
   useClock,
   usePanGestureHandler,
   useValue,
-  min,
+  minus,
+  clamp,
 } from "react-native-redash";
 
 import ItemLayout, { ItemModel, HEIGHT } from "./ItemLayout";
@@ -64,7 +65,7 @@ const Item = ({ item, onSwipe }: ItemProps) => {
     () => [
       cond(
         eq(state, State.ACTIVE),
-        set(translateX, add(offsetX, min(translation.x, 0)))
+        set(translateX, add(offsetX, clamp(translation.x,  -9999, minus(offsetX) )))
       ),
       cond(eq(state, State.END), [
         set(translateX, timing({ clock, from: translateX, to })),


### PR DESCRIPTION
* Fix scaling on Android. It seems `0.001` was too low of a scale number.
* Allow swiping to the starting position. Before it was impossible to close the opened "remove" option nicely, although `snapPoint` still worked and could snap back.

P. S.
You are doing an amazing job!