### PR TITLE
Add ' resizeMode: "cover" ' to Image.

### DIFF
--- a/season4/src/Snapchat/Story.tsx
+++ b/season4/src/Snapchat/Story.tsx
@@ -81,6 +81,7 @@ const Story = ({ route, navigation }: StoryProps) => {
                   ...StyleSheet.absoluteFillObject,
                   width: undefined,
                   height: undefined,
+                  resizeMode: "cover",
                 },
                 borderStyle,
               ]}


### PR DESCRIPTION
Add ' resizeMode: "cover" ' to Image because thumbnail Image has this style property.
conflict between property creates fluctuations because of shared element.

```diff
+ "resizeMode: "cover"
```