### PR TITLE
Fix onPress function state isn't updates

### DIFF
--- a/the-10-min/src/Ripple/RippleButton.tsx
+++ b/the-10-min/src/Ripple/RippleButton.tsx
@@ -46,7 +46,7 @@ const RippleButton = ({ children, color, onPress }: RippleButtonProps) => {
         cond(eq(state, State.END), [call([], onPress || (() => null))])
       ),
     ],
-    []
+    [onPress]
   );
   return (
     <TapGestureHandler {...gestureHandler}>


### PR DESCRIPTION
onPress will contain the initial value after it was changed

```
export const test = (props: testProps) => {
  const [value, setValue] = useState();
  
  const onPress = () => {
    console.log(value)
  }

  return (
    <View>
      <Ripple onPress={onPress} />
    </View>
  );
};
```