### PR TITLE
Fix card offset initailizing method

### DIFF
--- a/playground/src/Tarot/Card.tsx
+++ b/playground/src/Tarot/Card.tsx
@@ -61,8 +61,7 @@ export const Card = ({ card: { source }, shuffleBack, index }: CardProps) => {
   );
   const gesture = Gesture.Pan()
     .onBegin(() => {
-      offset.value.x = translateX.value;
-      offset.value.y = translateY.value;
+      offset.value = { x: translateX.value, y: translateY.value };
       rotateZ.value = withTiming(0);
       scale.value = withTiming(1.1);
     })


### PR DESCRIPTION
The way to change the individual values ​​of offset cannot initialize offset in onBegin callback of pan gesture.
It is need to change whole object value.