### PR TITLE
fix: changed from window to screen

### DIFF
--- a/season5/src/components/ColorSchemeContext.tsx
+++ b/season5/src/components/ColorSchemeContext.tsx
@@ -132,7 +132,7 @@ interface ColorSchemeProviderProps {
   children: ReactNode;
 }
 
-const { width, height } = Dimensions.get("window");
+const { width, height } = Dimensions.get("screen");
 const corners = [vec(0, 0), vec(width, 0), vec(width, height), vec(0, height)];
 
 export const ColorSchemeProvider = ({ children }: ColorSchemeProviderProps) => {


### PR DESCRIPTION
Changed from window to screen to work like a charm in android. `Dimensions.get('window')` ignore status bar height on android