### PR TITLE
chore: skip scroll when it's not required

### DIFF
--- a/season4/src/Chrome/Item.tsx
+++ b/season4/src/Chrome/Item.tsx
@@ -110,6 +110,9 @@ const Item = ({
         const upperBound = lowerBound + containerHeight - SIZE;
         const maxScroll = contentHeight - containerHeight;
         const leftToScrollDown = maxScroll - scrollY.value;
+        if (maxScroll <= 0) {
+          return;
+        }
         if (translateY.value < lowerBound) {
           const diff = Math.min(lowerBound - translateY.value, lowerBound);
           scrollY.value -= diff;


### PR DESCRIPTION
Scroll up/down logic isn't required when not enough content to scroll.